### PR TITLE
Add smooth theme color transitions

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2,11 +2,11 @@
 :root.light{--bg:#ffffff;--text:#0b0f14;--muted:#4b5563;--card:#f8fafc;--accent:#2563eb;--accent-2:#16a34a;--border:#e5e7eb}
 *{box-sizing:border-box}
 html{scroll-behavior:smooth}
-body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,'Helvetica Neue',Arial,'Noto Sans',sans-serif;background:var(--bg);color:var(--text);line-height:1.6}
+body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,'Helvetica Neue',Arial,'Noto Sans',sans-serif;background:var(--bg);color:var(--text);line-height:1.6;transition:background-color .3s ease,color .3s ease}
 img{max-width:100%;height:auto;border-radius:12px}
 .container{width:min(1100px,92%);margin-inline:auto}
 .section{padding:72px 0}
-.section.alt{background:var(--card)}
+.section.alt{background:var(--card);transition:background-color .3s ease,color .3s ease}
 .title{font-size:clamp(2rem,5vw,3rem);margin:0 0 8px}
 .tagline{color:var(--muted);font-size:1.1rem;margin:0 0 6px}
 .role{color:var(--muted);margin-bottom:18px}
@@ -19,7 +19,7 @@ img{max-width:100%;height:auto;border-radius:12px}
 .skip-link:focus{left:8px;top:8px;background:#000;color:#fff;padding:8px;border-radius:6px;z-index:1000}
 
 /* Header */
-.site-header{position:sticky;top:0;background:rgba(11,15,20,.8);backdrop-filter:saturate(180%) blur(10px);border-bottom:1px solid var(--border);z-index:50}
+.site-header{position:sticky;top:0;background:rgba(11,15,20,.8);backdrop-filter:saturate(180%) blur(10px);border-bottom:1px solid var(--border);z-index:50;transition:background-color .3s ease,color .3s ease}
 :root.light .site-header{background:rgba(255,255,255,.8)}
 .nav{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:12px 4%}
 .logo{font-weight:800;color:var(--text);text-decoration:none;font-size:1.1rem;letter-spacing:.5px}
@@ -28,7 +28,7 @@ img{max-width:100%;height:auto;border-radius:12px}
 .menu a:hover{background:rgba(255,255,255,.06)}
 .icon-btn{background:transparent;border:1px solid var(--border);color:var(--text);border-radius:8px;padding:8px 10px;cursor:pointer}
 @media (max-width:840px){
-  #menu{display:none;position:absolute;right:12px;top:56px;background:var(--card);border:1px solid var(--border);padding:12px 10px;border-radius:10px;flex-direction:column;gap:8px}
+  #menu{display:none;position:absolute;right:12px;top:56px;background:var(--card);border:1px solid var(--border);padding:12px 10px;border-radius:10px;flex-direction:column;gap:8px;transition:background-color .3s ease,color .3s ease}
   .menu.show{display:flex}
 }
 
@@ -48,14 +48,14 @@ img{max-width:100%;height:auto;border-radius:12px}
 .skills-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
 @media (max-width:1024px){.skills-grid{grid-template-columns:repeat(3,1fr)}}
 @media (max-width:720px){.skills-grid{grid-template-columns:repeat(2,1fr)}}
-.skill-card{background:var(--card);border:1px solid var(--border);padding:14px;border-radius:12px}
+.skill-card{background:var(--card);border:1px solid var(--border);padding:14px;border-radius:12px;transition:background-color .3s ease,color .3s ease}
 .skill-card h3{margin:0 0 8px;font-size:1rem}
 
 /* Cards */
 .cards{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
 @media (max-width:1024px){.cards{grid-template-columns:repeat(2,1fr)}}
 @media (max-width:720px){.cards{grid-template-columns:1fr}}
-.card{background:var(--card);border:1px solid var(--border);padding:18px;border-radius:14px;transition:border-color .2s,transform .2s}
+.card{background:var(--card);border:1px solid var(--border);padding:18px;border-radius:14px;transition:background-color .3s ease,color .3s ease,border-color .2s,transform .2s}
 .card:hover{transform:translateY(-2px);border-color:var(--accent)}
 .card header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
 .stack{color:var(--muted);font-size:.95rem}
@@ -67,10 +67,10 @@ img{max-width:100%;height:auto;border-radius:12px}
 
 /* Education */
 .edu-list{list-style:none;padding:0}
-.edu-list li{background:var(--card);border:1px solid var(--border);padding:12px;border-radius:12px;margin:10px 0}
+.edu-list li{background:var(--card);border:1px solid var(--border);padding:12px;border-radius:12px;margin:10px 0;transition:background-color .3s ease,color .3s ease}
 
 /* Footer */
-.site-footer{border-top:1px solid var(--border);padding:24px 0}
+.site-footer{border-top:1px solid var(--border);padding:24px 0;transition:background-color .3s ease,color .3s ease}
 .footer-grid{display:flex;align-items:center;justify-content:space-between;gap:16px}
 .social a{color:var(--text);text-decoration:none;font-weight:700;border:1px solid var(--border);padding:6px 10px;border-radius:8px}
 .social a:hover{background:rgba(255,255,255,.06)}


### PR DESCRIPTION
## Summary
- animate theme swaps by transitioning background and text colors on body, header and card components
- ensure additional containers like skill and education cards also fade between themes

## Testing
- `node - <<'NODE'
const fs=require('fs');const css=fs.readFileSync('assets/css/styles.css','utf8');
const bodyHas=/body\{[^}]*transition:background-color \.3s ease,color \.3s ease/i.test(css);
const headerHas=/\.site-header\{[^}]*transition:background-color \.3s ease,color \.3s ease/i.test(css);
const cardHas=/\.card\{[^}]*transition:background-color \.3s ease,color \.3s ease/i.test(css);
console.log('body transition',bodyHas);
console.log('header transition',headerHas);
console.log('card transition',cardHas);
const rootDark=css.match(/:root\{[^}]*--bg:([^;]+);/)[1];
const rootLight=css.match(/:root\.light\{[^}]*--bg:([^;]+);/)[1];
console.log('dark bg',rootDark.trim(),'light bg',rootLight.trim());
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6897285edd1c83318f8ac960a192977d