### PR TITLE
style: enhance hero section layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -33,10 +33,13 @@ img{max-width:100%;height:auto;border-radius:12px}
 }
 
 /* Hero */
+.hero{background:linear-gradient(135deg,var(--accent),var(--accent-2));min-height:80vh;display:grid;place-items:center;padding:72px 0}
 .grid-2{display:grid;grid-template-columns:1.2fr .8fr;gap:36px}
 @media (max-width:840px){.grid-2{grid-template-columns:1fr}}
+.hero-content{grid-template-columns:1fr 1fr;align-items:center}
+@media (max-width:840px){.hero-content{text-align:center}}
 .photo-wrap{display:flex;align-items:center;justify-content:center}
-.photo{width:min(280px,80%);aspect-ratio:1/1;object-fit:cover;border:2px solid var(--border);box-shadow:0 10px 30px rgba(0,0,0,.25)}
+.photo{width:min(260px,80%);aspect-ratio:1/1;object-fit:cover;border:2px solid var(--border);box-shadow:0 10px 30px rgba(0,0,0,.25)}
 
 /* Timeline */
 .timeline{border-left:2px dashed var(--border);margin-top:18px;padding-left:16px}

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
   <main id="main">
     <!-- Hero / Home -->
     <section id="home" class="section hero" aria-label="Homepage" data-animate>
-      <div class="container grid-2">
+      <div class="container grid-2 hero-content">
         <div>
           <h1 class="title">Rahul Krishnan</h1>
           <p class="tagline">"Turning data into insights. Engineering scalable ML solutions."</p>


### PR DESCRIPTION
## Summary
- add hero-content wrapper and gradient-styled hero section
- center hero content vertically with responsive grid
- adjust portrait sizing for proportionate layout

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68972861a8948331bd4770fd83e279b1