### PR TITLE
Add keyboard focus styles for interactive elements

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -13,6 +13,7 @@ img{max-width:100%;height:auto;border-radius:12px}
 .muted{color:var(--muted)}
 .btn{display:inline-block;background:var(--accent);color:white;padding:10px 14px;border-radius:10px;border:1px solid transparent;text-decoration:none;transition:.2s ease;font-weight:600}
 .btn:hover{transform:translateY(-1px);box-shadow:0 6px 18px rgba(59,130,246,.25)}
+.btn:focus-visible{transform:translateY(-1px);box-shadow:0 6px 18px rgba(59,130,246,.25);outline:2px solid var(--accent);outline-offset:2px}
 .btn.ghost{background:transparent;color:var(--text);border-color:var(--border)}
 .btn.small{padding:8px 10px;font-size:.9rem}
 .skip-link{position:absolute;left:-999px}
@@ -26,7 +27,9 @@ img{max-width:100%;height:auto;border-radius:12px}
 .menu{list-style:none;display:flex;gap:18px;margin:0;padding:0}
 .menu a{color:var(--text);text-decoration:none;border-radius:8px;padding:8px 10px}
 .menu a:hover{background:rgba(255,255,255,.06)}
+.menu a:focus-visible{background:rgba(255,255,255,.06);outline:2px solid var(--accent);outline-offset:2px}
 .icon-btn{background:transparent;border:1px solid var(--border);color:var(--text);border-radius:8px;padding:8px 10px;cursor:pointer}
+.icon-btn:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 @media (max-width:840px){
   #menu{display:none;position:absolute;right:12px;top:56px;background:var(--card);border:1px solid var(--border);padding:12px 10px;border-radius:10px;flex-direction:column;gap:8px}
   .menu.show{display:flex}
@@ -57,6 +60,7 @@ img{max-width:100%;height:auto;border-radius:12px}
 @media (max-width:720px){.cards{grid-template-columns:1fr}}
 .card{background:var(--card);border:1px solid var(--border);padding:18px;border-radius:14px;transition:border-color .2s,transform .2s}
 .card:hover{transform:translateY(-2px);border-color:var(--accent)}
+.card:focus-visible{transform:translateY(-2px);border-color:var(--accent);outline:2px solid var(--accent);outline-offset:2px}
 .card header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
 .stack{color:var(--muted);font-size:.95rem}
 .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}
@@ -74,6 +78,7 @@ img{max-width:100%;height:auto;border-radius:12px}
 .footer-grid{display:flex;align-items:center;justify-content:space-between;gap:16px}
 .social a{color:var(--text);text-decoration:none;font-weight:700;border:1px solid var(--border);padding:6px 10px;border-radius:8px}
 .social a:hover{background:rgba(255,255,255,.06)}
+.social a:focus-visible{background:rgba(255,255,255,.06);outline:2px solid var(--accent);outline-offset:2px}
 
 /* AOS-lite */
 [data-animate]{opacity:0;transform:translateY(8px);transition:opacity .6s ease,transform .6s ease}


### PR DESCRIPTION
## Summary
- add `:focus-visible` styles to buttons, menu links, icon buttons, cards, and social links
- use outlines to provide clear keyboard focus without layout shifts

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68972860aa408331831791e1f8afa43a