### PR TITLE
Add not-found styling and animation to 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,15 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Page not found</title>
   <link rel="stylesheet" href="assets/css/styles.css" />
-  <style>main{min-height:60vh;display:grid;place-items:center;text-align:center}</style>
 </head>
 <body>
   <main>
-    <div>
+    <section class="not-found">
+      <div class="icon" aria-hidden="true">🛸</div>
       <h1>404</h1>
       <p>Sorry, that page doesn’t exist.</p>
       <p><a class="btn" href="/">Go home</a></p>
-    </div>
+    </section>
   </main>
 </body>
 </html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -78,3 +78,26 @@ img{max-width:100%;height:auto;border-radius:12px}
 /* AOS-lite */
 [data-animate]{opacity:0;transform:translateY(8px);transition:opacity .6s ease,transform .6s ease}
 [data-animate].in{opacity:1;transform:none}
+
+/* 404 */
+.not-found{
+  min-height:60vh;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  background:linear-gradient(135deg,var(--accent),var(--accent-2));
+  color:#fff;
+}
+
+.not-found .icon{
+  font-size:4rem;
+  margin-bottom:16px;
+  animation:float 6s ease-in-out infinite;
+}
+
+@keyframes float{
+  0%,100%{transform:translateY(0)}
+  50%{transform:translateY(-10px)}
+}


### PR DESCRIPTION
## Summary
- add `.not-found` section to 404.html with playful icon
- style 404 page with gradient background and centered layout
- include floating animation for icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897285bf84c8331875684171b700a10